### PR TITLE
Fix CMAKE_C_STANDARD.

### DIFF
--- a/dll/CMakeLists.txt
+++ b/dll/CMakeLists.txt
@@ -3,6 +3,6 @@ project(hotkey_hook)
 
 add_definitions(-DDLL_COMPILE)
 
-set(CMAKE_C_STANDARD C99)
+set(CMAKE_C_STANDARD 99)
 
 add_library(hotkey_hook SHARED dllmain.c)


### PR DESCRIPTION
[C_STANDARD](https://cmake.org/cmake/help/v3.17/prop_tgt/C_STANDARD.html#prop_tgt:C_STANDARD) is `99` instead of `C99`.